### PR TITLE
refactor: replace wildcard imports in cloud2entities

### DIFF
--- a/cloud2entities.py
+++ b/cloud2entities.py
@@ -1,6 +1,20 @@
-from aux_functions import *
+import os
+import time
+import numpy as np
+
+from aux_functions import (
+    load_config_and_variables,
+    log,
+    read_e57,
+    e57_data_to_xyz,
+    load_xyz_file,
+    identify_slabs,
+    split_pointcloud_to_storeys,
+    identify_walls,
+    identify_openings,
+)
 from generate_ifc import IFCmodel
-from space_generator import *
+from space_generator import identify_zones
 
 # === Load Configuration ===
 config = load_config_and_variables()


### PR DESCRIPTION
## Summary
- replace wildcard imports with explicit imports for needed functions in `cloud2entities.py`
- add direct imports for `os`, `time`, and `numpy`
- import `identify_zones` from `space_generator` instead of using a wildcard

## Testing
- `python -m py_compile cloud2entities.py`


------
https://chatgpt.com/codex/tasks/task_e_6893bf134334832b886a5db27b33065e